### PR TITLE
hotfix: Invalid job name during restart process

### DIFF
--- a/node-restart.sh
+++ b/node-restart.sh
@@ -150,7 +150,7 @@ for node in $nodes; do
   fi
   
   echo -e "${blue}Initiating node restart job on $node...${nocolor}"
-  pod="node-restart-$(env LC_CTYPE=C < /dev/urandom | base64 | tr -dc 'a-z0-9' | fold -w 5 | head -n 1)"
+  pod="node-restart-$(env LC_CTYPE=C LC_ALL=C tr -dc a-z0-9 < /dev/urandom | head -c 5)"
   if $dryrun; then
     echo "kubectl create job $pod"
   else

--- a/node-restart.sh
+++ b/node-restart.sh
@@ -150,7 +150,7 @@ for node in $nodes; do
   fi
   
   echo -e "${blue}Initiating node restart job on $node...${nocolor}"
-  pod="node-restart-$(env LC_CTYPE=C tr -dc a-z0-9 < /dev/urandom | head -c 5)"
+  pod="node-restart-$(env LC_CTYPE=C < /dev/urandom | base64 | tr -dc 'a-z0-9' | fold -w 5 | head -n 1)"
   if $dryrun; then
     echo "kubectl create job $pod"
   else


### PR DESCRIPTION
Restart process fail to create batch job because of invalid string generated for pod name

`pod="node-restart-$(env LC_CTYPE=C tr -dc a-z0-9 < /dev/urandom | head -c 5)"`

Console error:
```
Initiating node restart job on k3s-xx...
The Job "node-restart-�����" is invalid: 
* metadata.name: Invalid value: "node-restart-�����": a DNS-1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')
* spec.template.labels: Invalid value: "node-restart-�����": a valid label must be an empty string or consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character (e.g. 'MyValue',  or 'my_value',  or '12345', regex used for validation is '(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?')
* spec.template.spec.containers[0].name: Invalid value: "node-restart-�����": a DNS-1123 label must consist of lower case alphanumeric characters or '-', and must start and end with an alphanumeric character (e.g. 'my-name',  or '123-abc', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?')
```