### PR TITLE
feat: Specify context in order to be able to manage several cluster in the same time

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 - perform rolling restart of all nodes in a cluster
 
 ```bash
-    kubectl node-restart all
+    kubectl node-restart [--context cluster] all
 ```
 
 - restart only specific nodes selected through labels


### PR DESCRIPTION
Hi @MnrGreg,

Thanks for the toy.

A tiny modification to be able to play on different clusters in the same time in a safe way. - I understand we actually have to enable the good context with kubectx for example, but if I switch the context while the script is running in the background, this can be dangerous. I let the parameter optional.

If you accept those modifications, can you do a release then ?

Thanks 🙏