### PR TITLE
Do not sleep after the last node

### DIFF
--- a/node-restart.sh
+++ b/node-restart.sh
@@ -224,6 +224,6 @@ EOT
     sleep $uncordondelay
     kubectl uncordon "$node" $context
     kubectl delete job $pod -n kube-system $context
-    sleep $nodesleep
+    [ "$node" != "${nodes##* }" ] && sleep $nodesleep
   fi
 done


### PR DESCRIPTION
In my opinion, there is no point in sleeping after the last node is completed. In fact, the documentation itself says "Sleep delay ***between*** restarting Nodes". There is no "***between*** nodes" after the last one.

The added code executes `sleep $nodesleep` after each node except the last one.

What do you think?